### PR TITLE
Update How Time is Displayed on Feed

### DIFF
--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -9,7 +9,7 @@ const Feed = ({ edges }) => (
       <div className={styles['feed__item']} key={edge.node.fields.slug}>
         <div className={styles['feed__item-meta']}>
           <time className={styles['feed__item-meta-time']} dateTime={moment(edge.node.frontmatter.date).format('MMMM D, YYYY')}>
-            {moment(edge.node.frontmatter.date).format('MMMM YYYY')}
+            {moment(edge.node.frontmatter.date).format('MMMM D, YYYY')}
           </time>
           <span className={styles['feed__item-meta-divider']} />
         </div>

--- a/src/components/Feed/Feed.module.scss
+++ b/src/components/Feed/Feed.module.scss
@@ -39,7 +39,6 @@
         font-size: $typographic-small-font-size;
         color: $color-base;
         font-weight: 600;
-        text-transform: uppercase;
       }
 
       &-divider {


### PR DESCRIPTION
* Change how the time is displayed above post name in the feed. It used to look like `JANUARY 2020` but now it should read `January 2, 2020` 